### PR TITLE
Change WebapiAsync topic to use Service contract name

### DIFF
--- a/app/code/Magento/WebapiAsync/Model/Config.php
+++ b/app/code/Magento/WebapiAsync/Model/Config.php
@@ -78,18 +78,18 @@ class Config implements \Magento\AsynchronousOperations\Model\ConfigInterface
     public function getTopicName($routeUrl, $httpMethod)
     {
         $services = $this->getServices();
-        $topicName = $this->generateTopicNameByRouteData(
+        $lookupKey = $this->generateLookupKeyByRouteData(
             $routeUrl,
             $httpMethod
         );
 
-        if (array_key_exists($topicName, $services) === false) {
+        if (array_key_exists($lookupKey, $services) === false) {
             throw new LocalizedException(
-                __('WebapiAsync config for "%topicName" does not exist.', ['topicName' => $topicName])
+                __('WebapiAsync config for "%lookupKey" does not exist.', ['lookupKey' => $lookupKey])
             );
         }
 
-        return $services[$topicName][self::SERVICE_PARAM_KEY_TOPIC];
+        return $services[$lookupKey][self::SERVICE_PARAM_KEY_TOPIC];
     }
 
     /**
@@ -105,11 +105,18 @@ class Config implements \Magento\AsynchronousOperations\Model\ConfigInterface
                     $serviceInterface = $httpMethodData[Converter::KEY_SERVICE][Converter::KEY_SERVICE_CLASS];
                     $serviceMethod = $httpMethodData[Converter::KEY_SERVICE][Converter::KEY_SERVICE_METHOD];
 
-                    $topicName = $this->generateTopicNameByRouteData(
+                    $lookupKey = $this->generateLookupKeyByRouteData(
                         $routeUrl,
                         $httpMethod
                     );
-                    $services[$topicName] = [
+
+                    $topicName = $this->generateTopicNameFromService(
+                        $serviceInterface,
+                        $serviceMethod,
+                        $httpMethod
+                    );
+
+                    $services[$lookupKey] = [
                         self::SERVICE_PARAM_KEY_INTERFACE => $serviceInterface,
                         self::SERVICE_PARAM_KEY_METHOD    => $serviceMethod,
                         self::SERVICE_PARAM_KEY_TOPIC     => $topicName,
@@ -122,7 +129,7 @@ class Config implements \Magento\AsynchronousOperations\Model\ConfigInterface
     }
 
     /**
-     * Generate topic name based on service type and method name.
+     * Generate lookup key name based on route and method
      *
      * Perform the following conversion:
      * self::TOPIC_PREFIX + /V1/products + POST => async.V1.products.POST
@@ -131,19 +138,39 @@ class Config implements \Magento\AsynchronousOperations\Model\ConfigInterface
      * @param string $httpMethod
      * @return string
      */
-    private function generateTopicNameByRouteData($routeUrl, $httpMethod)
+    private function generateLookupKeyByRouteData($routeUrl, $httpMethod)
     {
-        return self::TOPIC_PREFIX . $this->generateTopicName($routeUrl, $httpMethod, '/', false);
+        return self::TOPIC_PREFIX . $this->generateKey($routeUrl, $httpMethod, '/', false);
     }
 
     /**
+     * Generate topic name based on service type and method name.
+     *
+     * Perform the following conversion:
+     * self::TOPIC_PREFIX + Magento\Catalog\Api\ProductRepositoryInterface + save + POST
+     *   => async.magento.catalog.api.productrepositoryinterface.save.POST
+     *
+     * @param string $serviceMethod
+     * @param string $serviceInterface
+     * @param string $httpMethod
+     * @return string
+     */
+    private function generateTopicNameFromService($serviceInterface, $serviceMethod, $httpMethod)
+    {
+        $typeName = strtolower(sprintf('%s.%s', $serviceInterface, $serviceMethod));
+        return self::TOPIC_PREFIX . $this->generateKey($typeName, $httpMethod, '\\', false);
+    }
+
+    /**
+     * Join and simplify input type and method into a string that can be used as an array key
+     *
      * @param string $typeName
      * @param string $methodName
      * @param string $delimiter
      * @param bool $lcfirst
      * @return string
      */
-    private function generateTopicName($typeName, $methodName, $delimiter = '\\', $lcfirst = true)
+    private function generateKey($typeName, $methodName, $delimiter = '\\', $lcfirst = true)
     {
         $parts = explode($delimiter, ltrim($typeName, $delimiter));
         foreach ($parts as &$part) {

--- a/app/code/Magento/WebapiAsync/Test/Unit/Model/ConfigTest.php
+++ b/app/code/Magento/WebapiAsync/Test/Unit/Model/ConfigTest.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Magento\WebapiAsync\Test\Unit\Model;
+
+use Magento\Framework\Serialize\SerializerInterface;
+use Magento\Webapi\Model\Cache\Type\Webapi;
+use Magento\Webapi\Model\Config as WebapiConfig;
+use Magento\WebapiAsync\Model\Config;
+use Magento\Webapi\Model\Config\Converter;
+
+class ConfigTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var Config
+     */
+    private $config;
+
+    /**
+     * @var Webapi|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $webapiCacheMock;
+
+    /**
+     * @var WebapiConfig|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $configMock;
+
+    /**
+     * @var SerializerInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $serializerMock;
+
+    protected function setUp()
+    {
+        $objectManager = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
+
+        $this->webapiCacheMock = $this->createMock(\Magento\Webapi\Model\Cache\Type\Webapi::class);
+        $this->configMock = $this->createMock(WebapiConfig::class);
+        $this->serializerMock = $this->createMock(SerializerInterface::class);
+
+        $this->config = $objectManager->getObject(
+            Config::class,
+            [
+                'cache' => $this->webapiCacheMock,
+                'webApiConfig' => $this->configMock,
+                'serializer' => $this->serializerMock
+            ]
+        );
+    }
+
+    public function testGetServicesSetsTopicFromRoute()
+    {
+        $services = [
+            Converter::KEY_ROUTES => [
+                '/V1/products' => [
+                    'POST' => [
+                        'service' => [
+                            'class' => 'Magento\Catalog\Api\ProductRepositoryInterface',
+                            'method' => 'save',
+                        ]
+                    ]
+                ]
+            ]
+        ];
+        $this->configMock->expects($this->once())
+            ->method('getServices')
+            ->willReturn($services);
+
+        /* example of what $this->config->getServices() returns
+        $result = [
+            'async.V1.products.POST' => [
+                'interface' => 'Magento\Catalog\Api\ProductRepositoryInterface',
+                'method' => 'save',
+                'topic' => 'async.V1.products.POST',
+            ]
+        ];
+        */
+        $result = $this->config->getServices();
+
+        $expectedTopic = 'async.V1.products.POST';
+        $this->assertArrayHasKey($expectedTopic, $result);
+        $this->assertEquals($result[$expectedTopic]['topic'], $expectedTopic);
+    }
+}

--- a/app/code/Magento/WebapiAsync/Test/Unit/Model/ConfigTest.php
+++ b/app/code/Magento/WebapiAsync/Test/Unit/Model/ConfigTest.php
@@ -54,7 +54,7 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    public function testGetServicesSetsTopicFromRoute()
+    public function testGetServicesSetsTopicFromServiceContractName()
     {
         $services = [
             Converter::KEY_ROUTES => [
@@ -77,14 +77,14 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
             'async.V1.products.POST' => [
                 'interface' => 'Magento\Catalog\Api\ProductRepositoryInterface',
                 'method' => 'save',
-                'topic' => 'async.V1.products.POST',
+                'topic' => 'async.magento.catalog.api.productrepositoryinterface.save.POST',
             ]
         ];
         */
         $result = $this->config->getServices();
 
-        $expectedTopic = 'async.V1.products.POST';
-        $this->assertArrayHasKey($expectedTopic, $result);
-        $this->assertEquals($result[$expectedTopic]['topic'], $expectedTopic);
-    }
-}
+        $expectedTopic = 'async.magento.catalog.api.productrepositoryinterface.save.POST';
+        $lookupKey = 'async.V1.products.POST';
+        $this->assertArrayHasKey($lookupKey, $result);
+        $this->assertEquals($result[$lookupKey]['topic'], $expectedTopic);
+    }}


### PR DESCRIPTION
### Description
This change changes the topic used in the message queue for async api requests. The PR also adds a unit test over the functionality changed.

### Fixed Issues (if relevant)
1. magento/async-import#17: Topic should be mapped to the service contract name, not to the rest route

### Manual testing scenarios
1. Start with a Magento 2.3 installation, configured to use RabbitMQ as the queue
2. Ensure that Magento's queue consumer is not running, so you can inspect the queue content in RabbitMQ
3. Use curl or Postman or similar tools to create a async rest api call, e.g. POST the following data to /rest/default/async/bulk/V1/customers:
```
[{
	"customer": {
		"email": "mshaw@example.com",
		"firstname": "Melanie Shaw",
		"lastname": "Doe"
	}
},
{
	"customer": {
		"email": "bmartin@example.com",
		"firstname": "Bryce",
		"lastname": "Martin"
	}
}]
```
4. Inspect the message queue "async.operations.all"
5. Look at the routing_key (topic) and validate that it shows `async.magento.customer.api.accountmanagementinterface.createaccount.POST` instead of the previous topic `async.V1.customers.POST`

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
