### PR TITLE
Fix Swagger caching issue

### DIFF
--- a/app/code/Magento/Webapi/Model/ServiceMetadata.php
+++ b/app/code/Magento/Webapi/Model/ServiceMetadata.php
@@ -80,6 +80,11 @@ class ServiceMetadata
     private $serializer;
 
     /**
+     * @var string
+     */
+    private $routesConfigCacheId;
+
+    /**
      * Initialize dependencies.
      *
      * @param \Magento\Webapi\Model\Config $config
@@ -100,6 +105,7 @@ class ServiceMetadata
         $this->classReflector = $classReflector;
         $this->typeProcessor = $typeProcessor;
         $this->serializer = $serializer ?: ObjectManager::getInstance()->get(SerializerInterface::class);
+        $this->routesConfigCacheId = self::ROUTES_CONFIG_CACHE_ID;
     }
 
     /**
@@ -267,7 +273,7 @@ class ServiceMetadata
     public function getRoutesConfig()
     {
         if (null === $this->routes) {
-            $routesConfig = $this->cache->load(self::ROUTES_CONFIG_CACHE_ID);
+            $routesConfig = $this->cache->load($this->routesConfigCacheId);
             $typesData = $this->cache->load(self::REFLECTED_TYPES_CACHE_ID);
             if ($routesConfig && is_string($routesConfig) && $typesData && is_string($typesData)) {
                 $this->routes = $this->serializer->unserialize($routesConfig);
@@ -276,7 +282,7 @@ class ServiceMetadata
                 $this->routes = $this->initRoutesMetadata();
                 $this->cache->save(
                     $this->serializer->serialize($this->routes),
-                    self::ROUTES_CONFIG_CACHE_ID
+                    $this->routesConfigCacheId
                 );
                 $this->cache->save(
                     $this->serializer->serialize($this->typeProcessor->getTypesData()),
@@ -285,6 +291,17 @@ class ServiceMetadata
             }
         }
         return $this->routes;
+    }
+
+    /**
+     * Set Routes Config Cache ID
+     *
+     * @param string $routesConfigCacheId
+     */
+    public function setRoutesConfigCacheId($routesConfigCacheId){
+
+        $this->routesConfigCacheId = $routesConfigCacheId;
+
     }
 
     /**

--- a/app/code/Magento/Webapi/Model/ServiceMetadata.php
+++ b/app/code/Magento/Webapi/Model/ServiceMetadata.php
@@ -80,11 +80,6 @@ class ServiceMetadata
     private $serializer;
 
     /**
-     * @var string
-     */
-    private $routesConfigCacheId;
-
-    /**
      * Initialize dependencies.
      *
      * @param \Magento\Webapi\Model\Config $config
@@ -105,7 +100,6 @@ class ServiceMetadata
         $this->classReflector = $classReflector;
         $this->typeProcessor = $typeProcessor;
         $this->serializer = $serializer ?: ObjectManager::getInstance()->get(SerializerInterface::class);
-        $this->routesConfigCacheId = self::ROUTES_CONFIG_CACHE_ID;
     }
 
     /**
@@ -273,7 +267,7 @@ class ServiceMetadata
     public function getRoutesConfig()
     {
         if (null === $this->routes) {
-            $routesConfig = $this->cache->load($this->routesConfigCacheId);
+            $routesConfig = $this->cache->load(self::ROUTES_CONFIG_CACHE_ID);
             $typesData = $this->cache->load(self::REFLECTED_TYPES_CACHE_ID);
             if ($routesConfig && is_string($routesConfig) && $typesData && is_string($typesData)) {
                 $this->routes = $this->serializer->unserialize($routesConfig);
@@ -282,7 +276,7 @@ class ServiceMetadata
                 $this->routes = $this->initRoutesMetadata();
                 $this->cache->save(
                     $this->serializer->serialize($this->routes),
-                    $this->routesConfigCacheId
+                    self::ROUTES_CONFIG_CACHE_ID
                 );
                 $this->cache->save(
                     $this->serializer->serialize($this->typeProcessor->getTypesData()),

--- a/app/code/Magento/WebapiAsync/Plugin/ServiceMetadata.php
+++ b/app/code/Magento/WebapiAsync/Plugin/ServiceMetadata.php
@@ -15,9 +15,6 @@ use Magento\WebapiAsync\Model\ServiceConfig\Converter;
 
 class ServiceMetadata
 {
-
-    const ASYNC_ROUTES_CONFIG_CACHE_ID = 'async-routes-services-config';
-
     /**
      * @var \Magento\Webapi\Model\Config
      */
@@ -274,18 +271,5 @@ class ServiceMetadata
         }
 
         return $this->responseDefinitionReplacement;
-    }
-
-    /**
-     * Plugin to change config cache id for Asynchronous operations
-     *
-     * @return null
-     */
-    public function beforeGetRoutesConfig(\Magento\Webapi\Model\ServiceMetadata $subject)
-    {
-        if ($this->asynchronousSchemaRequestProcessor->canProcess($this->request)) {
-            $subject->setRoutesConfigCacheId(self::ASYNC_ROUTES_CONFIG_CACHE_ID);
-        }
-        return null;
     }
 }

--- a/app/code/Magento/WebapiAsync/Plugin/ServiceMetadata.php
+++ b/app/code/Magento/WebapiAsync/Plugin/ServiceMetadata.php
@@ -15,6 +15,9 @@ use Magento\WebapiAsync\Model\ServiceConfig\Converter;
 
 class ServiceMetadata
 {
+
+    const ASYNC_ROUTES_CONFIG_CACHE_ID = 'async-routes-services-config';
+
     /**
      * @var \Magento\Webapi\Model\Config
      */
@@ -271,5 +274,18 @@ class ServiceMetadata
         }
 
         return $this->responseDefinitionReplacement;
+    }
+
+    /**
+     * Plugin to change config cache id for Asynchronous operations
+     *
+     * @return null
+     */
+    public function beforeGetRoutesConfig(\Magento\Webapi\Model\ServiceMetadata $subject)
+    {
+        if ($this->asynchronousSchemaRequestProcessor->canProcess($this->request)) {
+            $subject->setRoutesConfigCacheId(self::ASYNC_ROUTES_CONFIG_CACHE_ID);
+        }
+        return null;
     }
 }


### PR DESCRIPTION
## Description (*)
We have next issue discovered by @keharper 

1) User opens usual Swagger URL first
2) User opens Async Swagger Url

### Actual result
Async Swagger shows GET requests and wrong response output

### Expected result
Async Swagger shows only POST PUT DELETE request and Async response body

### Reason
On first page load, Magento cache groups methods by static key. When async swagger loads, its getting those values from Cache and load wrong requests.


### Manual testing scenarios (*)
1) User opens usual Swagger URL first
2) User opens Async Swagger Url
3) Async swagger have to contain only POST, PUT, DELETE requests and correct response body

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
