### PR TITLE
issue #59 correct created_at in source

### DIFF
--- a/app/code/Magento/ImportService/Api/Data/SourceInterface.php
+++ b/app/code/Magento/ImportService/Api/Data/SourceInterface.php
@@ -93,6 +93,13 @@ interface SourceInterface extends ExtensibleDataInterface
     public function getCreatedAt();
 
     /**
+     * Set Import date
+     *
+     * @return string
+     */
+    public function setCreatedAt($date);
+
+    /**
      * Retrieve existing extension attributes object or create a new one.
      *
      * @return \Magento\ImportService\Api\Data\SourceExtensionInterface|null

--- a/app/code/Magento/ImportService/Model/Import/Processor/PersistentSourceProcessor.php
+++ b/app/code/Magento/ImportService/Model/Import/Processor/PersistentSourceProcessor.php
@@ -51,8 +51,9 @@ class PersistentSourceProcessor implements SourceProcessorInterface
         $sourceType = $this->sourceTypePool->getSourceType($source);
 
         /** save processed content get updated source object */
-        $source = $sourceType->save($source);
         $source->setCreatedAt(strftime('%Y-%m-%d %H:%M:%S', $this->dateTime->gmtTimestamp()));
+        $source = $sourceType->save($source);
+
 
         /** return response with details */
         return $response->setSource($source)->setSourceId($source->getSourceId())->setStatus($source->getStatus());

--- a/app/code/Magento/ImportService/Model/Import/Processor/PersistentSourceProcessor.php
+++ b/app/code/Magento/ImportService/Model/Import/Processor/PersistentSourceProcessor.php
@@ -11,6 +11,7 @@ use Magento\ImportService\Api\Data\SourceInterface;
 use Magento\ImportService\Api\Data\SourceUploadResponseInterface;
 use Magento\ImportService\Model\Import\SourceTypePool;
 use Magento\ImportService\ImportServiceException;
+use \Magento\Framework\Stdlib\DateTime\DateTime;
 
 /**
  * Define the source type pool and process the request
@@ -29,11 +30,11 @@ class PersistentSourceProcessor implements SourceProcessorInterface
 
     /**
      * @param SourceTypePool $sourceTypePool
-     * @param \Magento\Framework\Stdlib\DateTime\DateTime $dateTime
+     * @param DateTime $dateTime
      */
     public function __construct(
         SourceTypePool $sourceTypePool,
-        \Magento\Framework\Stdlib\DateTime\DateTime $dateTime
+        DateTime $dateTime
     ) {
         $this->sourceTypePool = $sourceTypePool;
         $this->dateTime = $dateTime;

--- a/app/code/Magento/ImportService/Model/Import/Processor/PersistentSourceProcessor.php
+++ b/app/code/Magento/ImportService/Model/Import/Processor/PersistentSourceProcessor.php
@@ -23,12 +23,20 @@ class PersistentSourceProcessor implements SourceProcessorInterface
     private $sourceTypePool;
 
     /**
+     * @var \Magento\Framework\Stdlib\DateTime\DateTime
+     */
+    protected $dateTime;
+
+    /**
      * @param SourceTypePool $sourceTypePool
+     * @param \Magento\Framework\Stdlib\DateTime\DateTime $dateTime
      */
     public function __construct(
-        SourceTypePool $sourceTypePool
+        SourceTypePool $sourceTypePool,
+        \Magento\Framework\Stdlib\DateTime\DateTime $dateTime
     ) {
         $this->sourceTypePool = $sourceTypePool;
+        $this->dateTime = $dateTime;
     }
 
     /**
@@ -44,6 +52,7 @@ class PersistentSourceProcessor implements SourceProcessorInterface
 
         /** save processed content get updated source object */
         $source = $sourceType->save($source);
+        $source->setCreatedAt(strftime('%Y-%m-%d %H:%M:%S', $this->dateTime->gmtTimestamp()));
 
         /** return response with details */
         return $response->setSource($source)->setSourceId($source->getSourceId())->setStatus($source->getStatus());

--- a/app/code/Magento/ImportService/Model/Import/Processor/PersistentSourceProcessor.php
+++ b/app/code/Magento/ImportService/Model/Import/Processor/PersistentSourceProcessor.php
@@ -54,7 +54,6 @@ class PersistentSourceProcessor implements SourceProcessorInterface
         $source->setCreatedAt(strftime('%Y-%m-%d %H:%M:%S', $this->dateTime->gmtTimestamp()));
         $source = $sourceType->save($source);
 
-
         /** return response with details */
         return $response->setSource($source)->setSourceId($source->getSourceId())->setStatus($source->getStatus());
     }

--- a/app/code/Magento/ImportService/Model/Source.php
+++ b/app/code/Magento/ImportService/Model/Source.php
@@ -118,6 +118,14 @@ class Source extends AbstractExtensibleModel implements SourceInterface
     }
 
     /**
+     * @inheritDoc
+     */
+    public function setCreatedAt($date)
+    {
+        return $this->setData(self::CREATED_AT, $date);
+    }
+
+    /**
      * @inheritdoc
      */
     public function getExtensionAttributes()


### PR DESCRIPTION
Fix "Created_at" data in response


### Description (*)
Fixed issue, when "created_at" field was empty in response on source saving. 

### Fixed Issues 
#59 Correct "created_at" in source resoonse

### Manual testing scenarios (*)
1. Call /rest/V1/import/source
2. Check result

