### PR TITLE
Add extension to measure bulk performance

### DIFF
--- a/app/code/Magento/BulkPerformance/Api/Data/OperationInterface.php
+++ b/app/code/Magento/BulkPerformance/Api/Data/OperationInterface.php
@@ -41,10 +41,10 @@ interface OperationInterface extends \Magento\Framework\Api\ExtensibleDataInterf
     /**
      * Operation id
      *
-     * @return int
+     * @return int|null
      * @since 100.2.0
      */
-    public function getId();
+    public function getId(): ?int;
 
     /**
      * Set operation id
@@ -53,15 +53,15 @@ interface OperationInterface extends \Magento\Framework\Api\ExtensibleDataInterf
      * @return $this
      * @since 100.2.0
      */
-    public function setId($id);
+    public function setId(int $id): OperationInterface;
 
     /**
      * Get bulk uuid
      *
-     * @return string
+     * @return string|null
      * @since 100.2.0
      */
-    public function getBulkUuid();
+    public function getBulkUuid(): ?string;
 
     /**
      * Set bulk uuid
@@ -70,15 +70,15 @@ interface OperationInterface extends \Magento\Framework\Api\ExtensibleDataInterf
      * @return $this
      * @since 100.2.0
      */
-    public function setBulkUuid($bulkId);
+    public function setBulkUuid(string $bulkId): OperationInterface;
 
     /**
      * Message Queue Topic
      *
-     * @return string
+     * @return string|null
      * @since 100.2.0
      */
-    public function getTopicName();
+    public function getTopicName(): ?string;
 
     /**
      * Set message queue topic
@@ -87,51 +87,49 @@ interface OperationInterface extends \Magento\Framework\Api\ExtensibleDataInterf
      * @return $this
      * @since 100.2.0
      */
-    public function setTopicName($topic);
+    public function setTopicName(string $topic): OperationInterface;
 
     /**
      * Serialized Data
      *
-     * @return string
+     * @return string|null
      * @since 100.2.0
      */
-    public function getSerializedData();
+    public function getSerializedData(): ?string;
 
     /**
      * Set serialized data
      *
-     * @param string $serializedData
+     * @param string|null $serializedData
      * @return $this
      * @since 100.2.0
      */
-    public function setSerializedData($serializedData);
+    public function setSerializedData(?string $serializedData): OperationInterface;
 
     /**
      * Result serialized Data
      *
-     * @return string
+     * @return string|null
      * @since 100.3.0
      */
-    public function getResultSerializedData();
+    public function getResultSerializedData(): ?string;
 
     /**
      * Set result serialized data
      *
-     * @param string $resultSerializedData
+     * @param string|null $resultSerializedData
      * @return $this
      * @since 100.3.0
      */
-    public function setResultSerializedData($resultSerializedData);
+    public function setResultSerializedData(?string $resultSerializedData): OperationInterface;
 
     /**
      * Get operation status
      *
-     * OPEN | COMPLETE | RETRIABLY_FAILED | NOT_RETRIABLY_FAILED
-     *
-     * @return int
+     * @return int|null
      * @since 100.2.0
      */
-    public function getStatus();
+    public function getStatus(): ?int;
 
     /**
      * Set status
@@ -140,64 +138,64 @@ interface OperationInterface extends \Magento\Framework\Api\ExtensibleDataInterf
      * @return $this
      * @since 100.2.0
      */
-    public function setStatus($status);
+    public function setStatus(int $status): OperationInterface;
 
     /**
      * Get result message
      *
-     * @return string
+     * @return string|null
      * @since 100.2.0
      */
-    public function getResultMessage();
+    public function getResultMessage(): ?string;
 
     /**
      * Set result message
      *
-     * @param string $resultMessage
+     * @param string|null $resultMessage
      * @return $this
      * @since 100.2.0
      */
-    public function setResultMessage($resultMessage);
+    public function setResultMessage(?string $resultMessage): OperationInterface;
 
     /**
      * Get created at
      *
-     * @return string
+     * @return string|null
      * @since 100.2.0
      */
-    public function getCreatedAt();
+    public function getCreatedAt(): ?string;
 
     /**
      * Get finished at
      *
-     * @return string
+     * @return string|null
      * @since 100.2.0
      */
-    public function getFinishedAt();
+    public function getFinishedAt(): ?string;
 
     /**
      * Set finished at
      *
-     * @param string $date
+     * @param string|null $date
      * @return $this
      * @since 100.2.0
      */
-    public function setFinishedAt($date);
+    public function setFinishedAt(?string $date): OperationInterface;
 
     /**
      * Get error code
      *
-     * @return int
+     * @return int|null
      * @since 100.2.0
      */
-    public function getErrorCode();
+    public function getErrorCode(): ?string;
 
     /**
      * Set error code
      *
-     * @param int $errorCode
+     * @param int|null $errorCode
      * @return $this
      * @since 100.2.0
      */
-    public function setErrorCode($errorCode);
+    public function setErrorCode(?string $errorCode): OperationInterface;
 }

--- a/app/code/Magento/BulkPerformance/Api/Data/OperationInterface.php
+++ b/app/code/Magento/BulkPerformance/Api/Data/OperationInterface.php
@@ -1,0 +1,203 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\BulkPerformance\Api\Data;
+
+/**
+ * Interface OperationInterface
+ * @api
+ * @since 100.2.0
+ */
+interface OperationInterface extends \Magento\Framework\Api\ExtensibleDataInterface
+{
+    /**#@+
+     * Constants for keys of data array. Identical to the name of the getter in snake case
+     */
+    const ID = 'id';
+    const BULK_ID = 'bulk_uuid';
+    const TOPIC_NAME = 'topic_name';
+    const SERIALIZED_DATA = 'serialized_data';
+    const RESULT_SERIALIZED_DATA = 'result_serialized_data';
+    const STATUS = 'status';
+    const RESULT_MESSAGE = 'result_message';
+    const ERROR_CODE = 'error_code';
+    const FINISHED_AT = 'finished_at';
+    const CREATED_AT = 'created_at';
+
+    /**#@-*/
+
+    /**#@+
+     * Status types
+     */
+    const STATUS_TYPE_COMPLETE = 1;
+    const STATUS_TYPE_RETRIABLY_FAILED = 2;
+    const STATUS_TYPE_NOT_RETRIABLY_FAILED = 3;
+    const STATUS_TYPE_OPEN = 4;
+    const STATUS_TYPE_REJECTED = 5;
+    /**#@-*/
+
+    /**
+     * Operation id
+     *
+     * @return int
+     * @since 100.2.0
+     */
+    public function getId();
+
+    /**
+     * Set operation id
+     *
+     * @param int $id
+     * @return $this
+     * @since 100.2.0
+     */
+    public function setId($id);
+
+    /**
+     * Get bulk uuid
+     *
+     * @return string
+     * @since 100.2.0
+     */
+    public function getBulkUuid();
+
+    /**
+     * Set bulk uuid
+     *
+     * @param string $bulkId
+     * @return $this
+     * @since 100.2.0
+     */
+    public function setBulkUuid($bulkId);
+
+    /**
+     * Message Queue Topic
+     *
+     * @return string
+     * @since 100.2.0
+     */
+    public function getTopicName();
+
+    /**
+     * Set message queue topic
+     *
+     * @param string $topic
+     * @return $this
+     * @since 100.2.0
+     */
+    public function setTopicName($topic);
+
+    /**
+     * Serialized Data
+     *
+     * @return string
+     * @since 100.2.0
+     */
+    public function getSerializedData();
+
+    /**
+     * Set serialized data
+     *
+     * @param string $serializedData
+     * @return $this
+     * @since 100.2.0
+     */
+    public function setSerializedData($serializedData);
+
+    /**
+     * Result serialized Data
+     *
+     * @return string
+     * @since 100.3.0
+     */
+    public function getResultSerializedData();
+
+    /**
+     * Set result serialized data
+     *
+     * @param string $resultSerializedData
+     * @return $this
+     * @since 100.3.0
+     */
+    public function setResultSerializedData($resultSerializedData);
+
+    /**
+     * Get operation status
+     *
+     * OPEN | COMPLETE | RETRIABLY_FAILED | NOT_RETRIABLY_FAILED
+     *
+     * @return int
+     * @since 100.2.0
+     */
+    public function getStatus();
+
+    /**
+     * Set status
+     *
+     * @param int $status
+     * @return $this
+     * @since 100.2.0
+     */
+    public function setStatus($status);
+
+    /**
+     * Get result message
+     *
+     * @return string
+     * @since 100.2.0
+     */
+    public function getResultMessage();
+
+    /**
+     * Set result message
+     *
+     * @param string $resultMessage
+     * @return $this
+     * @since 100.2.0
+     */
+    public function setResultMessage($resultMessage);
+
+    /**
+     * Get created at
+     *
+     * @return string
+     * @since 100.2.0
+     */
+    public function getCreatedAt();
+
+    /**
+     * Get finished at
+     *
+     * @return string
+     * @since 100.2.0
+     */
+    public function getFinishedAt();
+
+    /**
+     * Set finished at
+     *
+     * @param string $date
+     * @return $this
+     * @since 100.2.0
+     */
+    public function setFinishedAt($date);
+
+    /**
+     * Get error code
+     *
+     * @return int
+     * @since 100.2.0
+     */
+    public function getErrorCode();
+
+    /**
+     * Set error code
+     *
+     * @param int $errorCode
+     * @return $this
+     * @since 100.2.0
+     */
+    public function setErrorCode($errorCode);
+}

--- a/app/code/Magento/BulkPerformance/Api/FinishStatusInterface.php
+++ b/app/code/Magento/BulkPerformance/Api/FinishStatusInterface.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Magento\BulkPerformance\Api;
+
+/**
+ * Interface FinishStatusInterface.
+ *
+ * Bulk summary data with information about finished operations
+ *
+ * @api
+ */
+interface FinishStatusInterface
+{
+    /**
+     * Get summary data with information about finished operations.
+     *
+     * @param string $bulkUuid
+     * @return \Magento\BulkPerformance\Api\Data\OperationInterface[]
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     */
+    public function getFinishInformation(string $bulkUuid): array;
+
+}

--- a/app/code/Magento/BulkPerformance/Model/FinishOperationsStatus.php
+++ b/app/code/Magento/BulkPerformance/Model/FinishOperationsStatus.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Magento\BulkPerformance\Model;
+
+use Magento\Framework\Exception\NoSuchEntityException;
+
+use Magento\BulkPerformance\Api\FinishStatusInterface;
+use Magento\AsynchronousOperations\Model\ResourceModel\Operation\CollectionFactory;
+
+/**
+ * Class BulkStatus
+ */
+class FinishOperationsStatus implements FinishStatusInterface
+{
+    /**
+     * @var CollectionFactory
+     */
+    private $operationCollectionFactory;
+
+    /**
+     * Init dependencies.
+     *
+     * @param CollectionFactory $operationCollection
+     */
+    public function __construct(
+        CollectionFactory $operationCollection
+    ) {
+        $this->operationCollectionFactory = $operationCollection;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getFinishInformation($bulkUuid)
+    {
+        $operations = $this->operationCollectionFactory->create()->addFieldToFilter('bulk_uuid', $bulkUuid)->getItems();
+        return $operations;
+    }
+
+}

--- a/app/code/Magento/BulkPerformance/Model/Operation.php
+++ b/app/code/Magento/BulkPerformance/Model/Operation.php
@@ -1,0 +1,189 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\BulkPerformance\Model;
+
+use Magento\BulkPerformance\Api\Data\OperationInterface;
+use Magento\Framework\DataObject;
+
+/**
+ * Class Operation
+ */
+class Operation extends DataObject implements OperationInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function getId()
+    {
+        return $this->getData(self::ID);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setId($id)
+    {
+        return $this->setData(self::ID, $id);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getBulkUuid()
+    {
+        return $this->getData(self::BULK_ID);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setBulkUuid($bulkId)
+    {
+        return $this->setData(self::BULK_ID, $bulkId);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getTopicName()
+    {
+        return $this->getData(self::TOPIC_NAME);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setTopicName($topic)
+    {
+        return $this->setData(self::TOPIC_NAME, $topic);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getSerializedData()
+    {
+        return $this->getData(self::SERIALIZED_DATA);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setSerializedData($serializedData)
+    {
+        return $this->setData(self::SERIALIZED_DATA, $serializedData);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getResultSerializedData()
+    {
+        return $this->getData(self::RESULT_SERIALIZED_DATA);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setResultSerializedData($resultSerializedData)
+    {
+        return $this->setData(self::RESULT_SERIALIZED_DATA, $resultSerializedData);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getStatus()
+    {
+        return $this->getData(self::STATUS);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setStatus($status)
+    {
+        return $this->setData(self::STATUS, $status);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getResultMessage()
+    {
+        return $this->getData(self::RESULT_MESSAGE);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setResultMessage($resultMessage)
+    {
+        return $this->setData(self::RESULT_MESSAGE, $resultMessage);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getErrorCode()
+    {
+        return $this->getData(self::ERROR_CODE);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setErrorCode($errorCode)
+    {
+        return $this->setData(self::ERROR_CODE, $errorCode);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getCreatedAt()
+    {
+        return $this->getData(self::CREATED_AT);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getFinishedAt()
+    {
+        return $this->getData(self::FINISHED_AT);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setFinishedAt($date)
+    {
+        return $this->setData(self::FINISHED_AT, $date);
+    }
+
+    /**
+     * Retrieve existing extension attributes object.
+     *
+     * @return \Magento\AsynchronousOperations\Api\Data\OperationExtensionInterface|null
+     */
+    public function getExtensionAttributes()
+    {
+        return $this->getData(self::EXTENSION_ATTRIBUTES_KEY);
+    }
+
+    /**
+     * Set an extension attributes object.
+     *
+     * @param \Magento\AsynchronousOperations\Api\Data\OperationExtensionInterface $extensionAttributes
+     * @return $this
+     */
+    public function setExtensionAttributes(
+        \Magento\AsynchronousOperations\Api\Data\OperationExtensionInterface $extensionAttributes
+    ) {
+        return $this->setData(self::EXTENSION_ATTRIBUTES_KEY, $extensionAttributes);
+    }
+}

--- a/app/code/Magento/BulkPerformance/Model/Operation.php
+++ b/app/code/Magento/BulkPerformance/Model/Operation.php
@@ -16,7 +16,7 @@ class Operation extends DataObject implements OperationInterface
     /**
      * @inheritDoc
      */
-    public function getId()
+    public function getId(): ?int
     {
         return $this->getData(self::ID);
     }
@@ -24,7 +24,7 @@ class Operation extends DataObject implements OperationInterface
     /**
      * @inheritDoc
      */
-    public function setId($id)
+    public function setId(int $id): OperationInterface
     {
         return $this->setData(self::ID, $id);
     }
@@ -32,7 +32,7 @@ class Operation extends DataObject implements OperationInterface
     /**
      * @inheritDoc
      */
-    public function getBulkUuid()
+    public function getBulkUuid(): ?string
     {
         return $this->getData(self::BULK_ID);
     }
@@ -40,7 +40,7 @@ class Operation extends DataObject implements OperationInterface
     /**
      * @inheritDoc
      */
-    public function setBulkUuid($bulkId)
+    public function setBulkUuid(string $bulkId): OperationInterface
     {
         return $this->setData(self::BULK_ID, $bulkId);
     }
@@ -48,7 +48,7 @@ class Operation extends DataObject implements OperationInterface
     /**
      * @inheritDoc
      */
-    public function getTopicName()
+    public function getTopicName(): ?string
     {
         return $this->getData(self::TOPIC_NAME);
     }
@@ -56,7 +56,7 @@ class Operation extends DataObject implements OperationInterface
     /**
      * @inheritDoc
      */
-    public function setTopicName($topic)
+    public function setTopicName(string $topic): OperationInterface
     {
         return $this->setData(self::TOPIC_NAME, $topic);
     }
@@ -64,7 +64,7 @@ class Operation extends DataObject implements OperationInterface
     /**
      * @inheritDoc
      */
-    public function getSerializedData()
+    public function getSerializedData(): ?string
     {
         return $this->getData(self::SERIALIZED_DATA);
     }
@@ -72,7 +72,7 @@ class Operation extends DataObject implements OperationInterface
     /**
      * @inheritDoc
      */
-    public function setSerializedData($serializedData)
+    public function setSerializedData(?string $serializedData): OperationInterface
     {
         return $this->setData(self::SERIALIZED_DATA, $serializedData);
     }
@@ -80,7 +80,7 @@ class Operation extends DataObject implements OperationInterface
     /**
      * @inheritDoc
      */
-    public function getResultSerializedData()
+    public function getResultSerializedData(): ?string
     {
         return $this->getData(self::RESULT_SERIALIZED_DATA);
     }
@@ -88,7 +88,7 @@ class Operation extends DataObject implements OperationInterface
     /**
      * @inheritDoc
      */
-    public function setResultSerializedData($resultSerializedData)
+    public function setResultSerializedData(?string $resultSerializedData): OperationInterface
     {
         return $this->setData(self::RESULT_SERIALIZED_DATA, $resultSerializedData);
     }
@@ -96,7 +96,7 @@ class Operation extends DataObject implements OperationInterface
     /**
      * @inheritDoc
      */
-    public function getStatus()
+    public function getStatus(): ?int
     {
         return $this->getData(self::STATUS);
     }
@@ -104,7 +104,7 @@ class Operation extends DataObject implements OperationInterface
     /**
      * @inheritDoc
      */
-    public function setStatus($status)
+    public function setStatus(int $status): OperationInterface
     {
         return $this->setData(self::STATUS, $status);
     }
@@ -112,7 +112,7 @@ class Operation extends DataObject implements OperationInterface
     /**
      * @inheritDoc
      */
-    public function getResultMessage()
+    public function getResultMessage(): ?string
     {
         return $this->getData(self::RESULT_MESSAGE);
     }
@@ -120,7 +120,7 @@ class Operation extends DataObject implements OperationInterface
     /**
      * @inheritDoc
      */
-    public function setResultMessage($resultMessage)
+    public function setResultMessage(?string $resultMessage): OperationInterface
     {
         return $this->setData(self::RESULT_MESSAGE, $resultMessage);
     }
@@ -128,7 +128,7 @@ class Operation extends DataObject implements OperationInterface
     /**
      * @inheritDoc
      */
-    public function getErrorCode()
+    public function getErrorCode(): ?string
     {
         return $this->getData(self::ERROR_CODE);
     }
@@ -136,7 +136,7 @@ class Operation extends DataObject implements OperationInterface
     /**
      * @inheritDoc
      */
-    public function setErrorCode($errorCode)
+    public function setErrorCode(?string $errorCode): OperationInterface
     {
         return $this->setData(self::ERROR_CODE, $errorCode);
     }
@@ -144,7 +144,7 @@ class Operation extends DataObject implements OperationInterface
     /**
      * @inheritDoc
      */
-    public function getCreatedAt()
+    public function getCreatedAt(): ?string
     {
         return $this->getData(self::CREATED_AT);
     }
@@ -152,7 +152,7 @@ class Operation extends DataObject implements OperationInterface
     /**
      * @inheritDoc
      */
-    public function getFinishedAt()
+    public function getFinishedAt(): ?string
     {
         return $this->getData(self::FINISHED_AT);
     }
@@ -160,7 +160,7 @@ class Operation extends DataObject implements OperationInterface
     /**
      * @inheritDoc
      */
-    public function setFinishedAt($date)
+    public function setFinishedAt(?string $date): OperationInterface
     {
         return $this->setData(self::FINISHED_AT, $date);
     }
@@ -170,7 +170,7 @@ class Operation extends DataObject implements OperationInterface
      *
      * @return \Magento\AsynchronousOperations\Api\Data\OperationExtensionInterface|null
      */
-    public function getExtensionAttributes()
+    public function getExtensionAttributes(): \Magento\AsynchronousOperations\Api\Data\OperationExtensionInterface
     {
         return $this->getData(self::EXTENSION_ATTRIBUTES_KEY);
     }
@@ -183,7 +183,7 @@ class Operation extends DataObject implements OperationInterface
      */
     public function setExtensionAttributes(
         \Magento\AsynchronousOperations\Api\Data\OperationExtensionInterface $extensionAttributes
-    ) {
+    ): OperationInterface {
         return $this->setData(self::EXTENSION_ATTRIBUTES_KEY, $extensionAttributes);
     }
 }

--- a/app/code/Magento/BulkPerformance/Model/OperationManagement.php
+++ b/app/code/Magento/BulkPerformance/Model/OperationManagement.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\BulkPerformance\Model;
+
+use Magento\AsynchronousOperations\Api\Data\OperationInterfaceFactory;
+use Magento\Framework\EntityManager\EntityManager;
+
+/**
+ * Class OperationManagement
+ */
+class OperationManagement implements \Magento\Framework\Bulk\OperationManagementInterface
+{
+    /**
+     * @var EntityManager
+     */
+    private $entityManager;
+
+    /**
+     * @var OperationInterfaceFactory
+     */
+    private $operationFactory;
+
+    /**
+     * @var \Psr\Log\LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * OperationManagement constructor.
+     *
+     * @param EntityManager $entityManager
+     * @param OperationInterfaceFactory $operationFactory
+     * @param \Psr\Log\LoggerInterface $logger
+     */
+    public function __construct(
+        EntityManager $entityManager,
+        OperationInterfaceFactory $operationFactory,
+        \Psr\Log\LoggerInterface $logger
+    ) {
+        $this->entityManager = $entityManager;
+        $this->operationFactory = $operationFactory;
+        $this->logger = $logger;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function changeOperationStatus(
+        $operationId,
+        $status,
+        $errorCode = null,
+        $message = null,
+        $data = null,
+        $resultData = null
+    ) {
+        try {
+            $operationEntity = $this->operationFactory->create();
+            $this->entityManager->load($operationEntity, $operationId);
+            $operationEntity->setErrorCode($errorCode);
+            $operationEntity->setStatus($status);
+            $operationEntity->setResultMessage($message);
+            $operationEntity->setSerializedData($data);
+            $operationEntity->setFinishedAt(date("Y-m-d H:i:s"));
+            $operationEntity->setResultSerializedData($resultData);
+            $this->entityManager->save($operationEntity);
+        } catch (\Exception $exception) {
+            $this->logger->critical($exception->getMessage());
+            return false;
+        }
+        return true;
+    }
+}

--- a/app/code/Magento/BulkPerformance/Model/OperationManagement.php
+++ b/app/code/Magento/BulkPerformance/Model/OperationManagement.php
@@ -64,7 +64,7 @@ class OperationManagement implements \Magento\Framework\Bulk\OperationManagement
             $operationEntity->setStatus($status);
             $operationEntity->setResultMessage($message);
             $operationEntity->setSerializedData($data);
-            $operationEntity->setFinishedAt(date("Y-m-d H:i:s"));
+            $operationEntity->setFinishedAt(time());
             $operationEntity->setResultSerializedData($resultData);
             $this->entityManager->save($operationEntity);
         } catch (\Exception $exception) {

--- a/app/code/Magento/BulkPerformance/composer.json
+++ b/app/code/Magento/BulkPerformance/composer.json
@@ -1,0 +1,25 @@
+{
+    "name": "magento/module-bulk-performance",
+    "description": "N/A",
+    "config": {
+        "sort-packages": true
+    },
+    "require": {
+        "php": "~7.1.3||~7.2.0",
+        "magento/framework": "102.0.*"
+    },
+    "type": "magento2-module",
+    "license": [
+        "OSL-3.0",
+        "AFL-3.0"
+    ],
+    "autoload": {
+        "files": [
+            "registration.php"
+        ],
+        "psr-4": {
+            "Magento\\BulkPerformance\\": ""
+        }
+    },
+    "version": "100.3.1"
+}

--- a/app/code/Magento/BulkPerformance/etc/communication.xml
+++ b/app/code/Magento/BulkPerformance/etc/communication.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Communication/etc/communication.xsd">
+    <topic name="async.system.required.wrapper.topic" is_synchronous="false" request="Magento\BulkPerformance\Api\Data\OperationInterface" request_type="object_interface"></topic>
+</config>

--- a/app/code/Magento/BulkPerformance/etc/db_schema.xml
+++ b/app/code/Magento/BulkPerformance/etc/db_schema.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:Setup/Declaration/Schema/etc/schema.xsd">
+    <table name="magento_operation" resource="default" engine="innodb" comment="Operation entity">
+        <column xsi:type="timestamp" name="created_at" on_update="false" nullable="false" default="CURRENT_TIMESTAMP"
+                comment="Operation start time"/>
+        <column xsi:type="timestamp" name="finished_at" on_update="false" nullable="false"
+            comment="Operation finished time"/>
+    </table>
+</schema>

--- a/app/code/Magento/BulkPerformance/etc/db_schema_whitelist.json
+++ b/app/code/Magento/BulkPerformance/etc/db_schema_whitelist.json
@@ -1,0 +1,23 @@
+{
+    "magento_operation": {
+        "column": {
+            "id": true,
+            "bulk_uuid": true,
+            "topic_name": true,
+            "serialized_data": true,
+            "result_serialized_data": true,
+            "status": true,
+            "error_code": true,
+            "result_message": true,
+            "created_at": true,
+            "finished_at": true
+        },
+        "index": {
+            "MAGENTO_OPERATION_BULK_UUID_ERROR_CODE": true
+        },
+        "constraint": {
+            "PRIMARY": true,
+            "MAGENTO_OPERATION_BULK_UUID_MAGENTO_BULK_UUID": true
+        }
+    }
+}

--- a/app/code/Magento/BulkPerformance/etc/di.xml
+++ b/app/code/Magento/BulkPerformance/etc/di.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <preference for="Magento\AsynchronousOperations\Model\Operation" type="Magento\BulkPerformance\Model\Operation" />
+    <preference for="Magento\AsynchronousOperations\Model\OperationManagement" type="Magento\BulkPerformance\Model\OperationManagement" />
+    <preference for="Magento\BulkPerformance\Api\Data\OperationInterface" type="Magento\BulkPerformance\Model\Operation" />
+    <preference for="Magento\BulkPerformance\Api\FinishStatusInterface" type="Magento\BulkPerformance\Model\FinishOperationsStatus" />
+
+    <type name="Magento\Framework\EntityManager\MetadataPool">
+        <arguments>
+            <argument name="metadata" xsi:type="array">
+                <item name="Magento\BulkPerformance\Api\Data\OperationInterface" xsi:type="array">
+                    <item name="entityTableName" xsi:type="string">magento_operation</item>
+                    <item name="identifierField" xsi:type="string">id</item>
+                </item>
+            </argument>
+        </arguments>
+    </type>
+</config>

--- a/app/code/Magento/BulkPerformance/etc/module.xml
+++ b/app/code/Magento/BulkPerformance/etc/module.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
+    <module name="Magento_BulkPerformance" >
+        <sequence>
+            <module name="Magento_Webapi"/>
+            <module name="Magento_WebapiAsync"/>
+        </sequence>
+    </module>
+</config>

--- a/app/code/Magento/BulkPerformance/etc/webapi.xml
+++ b/app/code/Magento/BulkPerformance/etc/webapi.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<routes xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Webapi:etc/webapi.xsd">
+
+    <route url="/V1/bulk/:bulkUuid/finish" method="GET">
+        <service class="Magento\BulkPerformance\Api\FinishStatusInterface" method="getFinishInformation"/>
+        <resources>
+            <resource ref="Magento_Logging::system_magento_logging_bulk_operations" />
+        </resources>
+    </route>
+
+</routes>

--- a/app/code/Magento/BulkPerformance/registration.php
+++ b/app/code/Magento/BulkPerformance/registration.php
@@ -1,0 +1,9 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+use \Magento\Framework\Component\ComponentRegistrar;
+
+ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_BulkPerformance', __DIR__);


### PR DESCRIPTION
### Description (*)
I created small extension for we can track performance of Asynchronous Import Module in future

Extension will add 2 new columns to magento_operation table with "created_at" and "finished_at" for we can track how much time each operation takes. 

In addition new endpoint were provided:

`GET {{URL}}rest/all/V1/bulk/:uuid/finish`

with response: 
```
[
    {
        "id": 115,
        "bulk_uuid": "80f38e7c-8470-4907-9766-0ec794d8b4f2",
        "topic_name": "async.magento.catalog.api.productrepositoryinterface.save.post",
        "serialized_data": null,
        "result_serialized_data": "}",
        "status": 1,
        "result_message": "Service execution success Magento\\Catalog\\Model\\ProductRepository\\Interceptor::save",
        "created_at": "2019-05-17 07:57:19",
        "finished_at": "2019-05-17 07:57:39",
        "error_code": null
    }
]
```

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
