### PR TITLE
Add OperationStatusPool and OperationStatusValidator

### DIFF
--- a/app/code/Magento/BulkPerformance/Model/Operation.php
+++ b/app/code/Magento/BulkPerformance/Model/Operation.php
@@ -6,6 +6,7 @@
 namespace Magento\BulkPerformance\Model;
 
 use Magento\BulkPerformance\Api\Data\OperationInterface;
+use Magento\BulkPerformance\Model\OperationStatusValidator;
 use Magento\Framework\DataObject;
 
 /**
@@ -13,6 +14,25 @@ use Magento\Framework\DataObject;
  */
 class Operation extends DataObject implements OperationInterface
 {
+    /**
+     * @var OperationStatusValidator
+     */
+    protected $operationStatusValidator;
+
+    /**
+     * Operation constructor.
+     *
+     * @param array $data
+     * @param OperationStatusValidator $operationStatusValidator
+     */
+    public function __construct(
+        array $data = [],
+        OperationStatusValidator $operationStatusValidator
+    ) {
+        $this->operationStatusValidator = $operationStatusValidator;
+        parent::__construct($data);
+    }
+
     /**
      * @inheritDoc
      */
@@ -106,6 +126,7 @@ class Operation extends DataObject implements OperationInterface
      */
     public function setStatus($status)
     {
+        $this->operationStatusValidator->validate($status);
         return $this->setData(self::STATUS, $status);
     }
 

--- a/app/code/Magento/BulkPerformance/Model/OperationStatusPool.php
+++ b/app/code/Magento/BulkPerformance/Model/OperationStatusPool.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\BulkPerformance\Model;
+
+/**
+ * Class OperationStatusPool
+ *
+ * Pool of statuses that require validate
+ */
+class OperationStatusPool
+{
+    /**
+     * @var array
+     */
+    protected $statuses;
+
+    /**
+     * @param array $statuses
+     */
+    public function __construct(array $statuses = [])
+    {
+        $this->statuses = $statuses;
+    }
+
+    /**
+     * Retrieve statuses that require validate
+     *
+     * @return array
+     */
+    public function getStatuses()
+    {
+        return $this->statuses;
+    }
+}

--- a/app/code/Magento/BulkPerformance/Model/OperationStatusValidator.php
+++ b/app/code/Magento/BulkPerformance/Model/OperationStatusValidator.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\BulkPerformance\Model;
+
+use Magento\BulkPerformance\Model\OperationStatusPool;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Doctrine\Instantiator\Exception\InvalidArgumentException;
+
+/**
+ * Class OperationStatusValidator to validate operation status
+ */
+class OperationStatusValidator
+{
+    /**
+     * @var OperationStatusPool
+     */
+    protected $operationStatusPool;
+
+    /**
+     * OperationStatusValidator constructor.
+     *
+     * @param OperationStatusPool $operationStatusPool
+     */
+    public function __construct(OperationStatusPool $operationStatusPool)
+    {
+        $this->operationStatusPool = $operationStatusPool;
+    }
+
+    /**
+     * Validate method
+     *
+     * @param $status
+     */
+    public function validate($status)
+    {
+        $statuses = $this->operationStatusPool->getStatuses();
+
+        if (!in_array($status, $statuses)) {
+            throw new \InvalidArgumentException('Invalid Operation Status.');
+        }
+
+        return;
+    }
+}

--- a/app/code/Magento/BulkPerformance/etc/di.xml
+++ b/app/code/Magento/BulkPerformance/etc/di.xml
@@ -21,4 +21,16 @@
             </argument>
         </arguments>
     </type>
+
+    <type name="Magento\BulkPerformance\Model\OperationStatusPool">
+        <arguments>
+            <argument name="statuses" xsi:type="array">
+                <item name="complete" xsi:type="string">1</item>
+                <item name="retriablyFailed" xsi:type="string">2</item>
+                <item name="notRetriablyFailed" xsi:type="string">3</item>
+                <item name="open" xsi:type="string">4</item>
+                <item name="rejected" xsi:type="string">5</item>
+            </argument>
+        </arguments>
+    </type>
 </config>


### PR DESCRIPTION
### Description

Added Magento\BulkPerformance\Model\OperationStatusPool and Magento\BulkPerformance\Model\OperationStatusValidator classes. 
Added list of statuses to Magento\BulkPerformance\Model\OperationStatusPool with di.xml file.
Added validation to Magento\BulkPerformance\Model\Operation::setStatus method. 

### Fixed Issues

1. magento/async-import#100: Add Operation Status validator

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
