### PR TITLE
Set url /V1/import/source/csv + Changed Interface to SourceCsvUploadI…

### DIFF
--- a/app/code/Magento/ImportService/Api/SourceCsvUploadInterface.php
+++ b/app/code/Magento/ImportService/Api/SourceCsvUploadInterface.php
@@ -12,14 +12,13 @@ use Magento\ImportService\Api\Data\SourceInterface;
 /**
  * Class ImportProcessor
  */
-interface SourceUploadInterface
+interface SourceCsvUploadInterface
 {
     /**
      * Upload source.
      *
-     * @param string $sourceType
      * @param \Magento\ImportService\Api\Data\SourceInterface $source
      * @return \Magento\ImportService\Api\Data\SourceUploadResponseInterface
      */
-    public function execute(string $sourceType, SourceInterface $source);
+    public function execute(SourceInterface $source);
 }

--- a/app/code/Magento/ImportService/Model/SourceCsvUpload.php
+++ b/app/code/Magento/ImportService/Model/SourceCsvUpload.php
@@ -9,14 +9,18 @@ namespace Magento\ImportService\Model;
 
 use Magento\ImportService\Api\Data\SourceInterface;
 use Magento\ImportService\Model\Import\SourceProcessorPool;
-use Magento\ImportService\Api\SourceUploadInterface;
+use Magento\ImportService\Api\SourceCsvUploadInterface;
 use Magento\ImportService\Model\Import\Type\FileSourceType;
 
 /**
- * Class SourceUpload
+ * Class SourceCsvUpload
  */
-class SourceUpload implements SourceUploadInterface
+class SourceCsvUpload implements SourceCsvUploadInterface
 {
+    /**
+     * const SOURCE_TYPE
+     */
+    const SOURCE_TYPE = "csv";
 
     /**
      * @var SourceProcessorPool
@@ -41,14 +45,13 @@ class SourceUpload implements SourceUploadInterface
     }
 
     /**
-     * @param string $sourceType
      * @param SourceInterface $source
      * @return SourceUploadResponseFactory
      */
-    public function execute(string $sourceType, SourceInterface $source)
+    public function execute(SourceInterface $source)
     {
         try {
-            $source->setSourceType($sourceType);
+            $source->setSourceType(self::SOURCE_TYPE);
             $processor = $this->sourceProcessorPool->getProcessor($source);
             $response = $this->responseFactory->create();
             $processor->processUpload($source, $response);

--- a/app/code/Magento/ImportService/etc/di.xml
+++ b/app/code/Magento/ImportService/etc/di.xml
@@ -7,8 +7,8 @@
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
-    <preference for="Magento\ImportService\Api\SourceUploadInterface"
-                type="Magento\ImportService\Model\SourceUpload" />
+    <preference for="Magento\ImportService\Api\SourceCsvUploadInterface"
+                type="Magento\ImportService\Model\SourceCsvUpload" />
     <preference for="Magento\ImportService\Api\Data\SourceInterface"
                 type="Magento\ImportService\Model\Source" />
     <preference for="Magento\ImportService\Api\Data\SourceFormatInterface"

--- a/app/code/Magento/ImportService/etc/webapi.xml
+++ b/app/code/Magento/ImportService/etc/webapi.xml
@@ -7,8 +7,8 @@
 -->
 <routes xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Webapi:etc/webapi.xsd">
-    <route url="/V1/import/source/:sourceType" method="POST">
-        <service class="Magento\ImportService\Api\SourceUploadInterface" method="execute"/>
+    <route url="/V1/import/source/csv" method="POST">
+        <service class="Magento\ImportService\Api\SourceCsvUploadInterface" method="execute"/>
         <resources>
             <resource ref="Magento_ImportService::import" />
         </resources>


### PR DESCRIPTION
### Description

Set url /V1/import/source/csv
Changed Interface to SourceCsvUploadInterface

### Fixed Issues

1. magento/async-import#106: Fix file type in URL to "csv"

### Manual testing scenarios (*)

1. Open Postman or another REST-query application.
2. Perform {base_url}/rest/V1/import/source/csv query with POST type and appropriate params.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
