### PR TITLE
Data seperator is moved to dependency injection

### DIFF
--- a/app/code/Magento/AsynchronousImportSourceDataRetrieving/Model/SourceDataRetrievingStrategy/Base64EncodedData.php
+++ b/app/code/Magento/AsynchronousImportSourceDataRetrieving/Model/SourceDataRetrievingStrategy/Base64EncodedData.php
@@ -21,13 +21,27 @@ class Base64EncodedData implements RetrieveSourceDataStrategyInterface
     private $batchSize = 3;
 
     /**
+     * @var string
+     */
+    private $dataSeparator;
+
+    /*
+     * @param string $dataSeparator
+     */
+    public function __construct(
+        $dataSeparator
+    ){
+        $this->dataSeparator = $dataSeparator;
+    }
+
+    /**
      * @inheritdoc
      */
     public function execute(SourceInterface $source): \Traversable
     {
         // phpcs:ignore Magento2.Functions.DiscouragedFunction
         $data = base64_decode($source->getSourceDefinition());
-        $data = explode("\n", $data);
+        $data = explode($this->dataSeparator, $data);
 
         $offset = 0;
         while ($sub = array_slice($data, $offset, $this->batchSize)) {

--- a/app/code/Magento/AsynchronousImportSourceDataRetrieving/Model/SourceDataRetrievingStrategy/Base64EncodedData.php
+++ b/app/code/Magento/AsynchronousImportSourceDataRetrieving/Model/SourceDataRetrievingStrategy/Base64EncodedData.php
@@ -25,12 +25,12 @@ class Base64EncodedData implements RetrieveSourceDataStrategyInterface
      */
     private $dataSeparator;
 
-    /*
+    /**
      * @param string $dataSeparator
      */
     public function __construct(
         $dataSeparator
-    ){
+    ) {
         $this->dataSeparator = $dataSeparator;
     }
 

--- a/app/code/Magento/AsynchronousImportSourceDataRetrieving/etc/di.xml
+++ b/app/code/Magento/AsynchronousImportSourceDataRetrieving/etc/di.xml
@@ -38,4 +38,10 @@
             </argument>
         </arguments>
     </type>
+    <!-- Base64 Encoded Data -->
+    <type name="Magento\AsynchronousImportSourceDataRetrieving\Model\SourceDataRetrievingStrategy\Base64EncodedData">
+        <arguments>
+            <argument name="dataSeparator" xsi:type="string">\n</argument>
+        </arguments>
+    </type>
 </config>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR is regarding static data separator which is moved to DI configuration so that it can easily be changes

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/async-import#215: Move data separator to DI configuration

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
