### PR TITLE
[PROTOTYPE] Add strategy based conerting rules

### DIFF
--- a/app/code/Magento/AsynchronousImportDataConverting/Model/ApplyConvertingRules.php
+++ b/app/code/Magento/AsynchronousImportDataConverting/Model/ApplyConvertingRules.php
@@ -19,6 +19,9 @@ use Magento\Framework\Validation\ValidationResultFactory;
  */
 class ApplyConvertingRules implements ApplyConvertingRulesInterface
 {
+
+    public const DEFAULT_APPLY_STRATEGIES_KEY = "default";
+
     /**
      * @var ConvertingRuleValidatorInterface
      */
@@ -35,6 +38,11 @@ class ApplyConvertingRules implements ApplyConvertingRulesInterface
     private $ruleApplyingStrategies;
 
     /**
+     * @var string
+     */
+    private $rulesEnabledStrategy;
+
+    /**
      * @param ConvertingRuleValidatorInterface $convertingRuleValidator
      * @param ValidationResultFactory $validationResultFactory
      * @param ApplyConvertingRuleStrategyInterface[] $ruleApplyingStrategies
@@ -47,15 +55,12 @@ class ApplyConvertingRules implements ApplyConvertingRulesInterface
     ) {
         $this->convertingRuleValidator = $convertingRuleValidator;
         $this->validationResultFactory = $validationResultFactory;
-
-        foreach ($ruleApplyingStrategies as $ruleApplyingStrategy) {
-            if (!$ruleApplyingStrategy instanceof ApplyConvertingRuleStrategyInterface) {
-                throw new ApplyConvertingRulesException(
-                    __('Apply converting rule strategy must implement %1.', ApplyConvertingRuleStrategyInterface::class)
-                );
-            }
-        }
         $this->ruleApplyingStrategies = $ruleApplyingStrategies;
+        /**
+         * @ToDo use configuration for define default default rules pool
+         */
+        $this->rulesEnabledStrategy = "service_contracts";
+        $this->filterApplyStrategies();
     }
 
     /**
@@ -63,6 +68,12 @@ class ApplyConvertingRules implements ApplyConvertingRulesInterface
      */
     public function execute(array $importData, array $convertingRules): array
     {
+        usort(
+            $convertingRules,
+            function ($previousRule, $nextRule) {
+                return $previousRule['sort'] <=> $nextRule['sort'];
+            }
+        );
         foreach ($convertingRules as $convertingRule) {
             $validationResult = $this->convertingRuleValidator->validate($convertingRule);
             if (false === $validationResult->isValid()) {
@@ -83,9 +94,30 @@ class ApplyConvertingRules implements ApplyConvertingRulesInterface
                 );
                 throw new ValidationException(__('Validation Failed.'), null, 0, $validationResult);
             }
-            $importData = $this->ruleApplyingStrategies[$convertingRule->getIdentifier()]
-                ->execute($importData, $convertingRule);
+            $importData = $this->ruleApplyingStrategies[$identifier]->execute($importData, $convertingRule);
         }
         return $importData;
+    }
+
+    /**
+     * Filter stretegies based on system settings
+     */
+    private function filterApplyStrategies(){
+
+        $activeApplyStrategies = [];
+        foreach ($this->ruleApplyingStrategies as $strategyKey => $implementations) {
+            $activeStrategy = $implementations[$this->rulesEnabledStrategy]
+                ?? $implementations[self::DEFAULT_APPLY_STRATEGIES_KEY]
+                ?? false;
+
+            if ($activeStrategy !== false && !$activeStrategy instanceof ApplyConvertingRuleStrategyInterface) {
+                throw new ApplyConvertingRulesException(
+                    __('Apply converting rule strategy must implement %1.', ApplyConvertingRuleStrategyInterface::class)
+                );
+            }
+            $activeStrategy ? $activeApplyStrategies[$strategyKey] = $activeStrategy : false;
+        }
+        $this->ruleApplyingStrategies = $activeApplyStrategies;
+
     }
 }

--- a/app/code/Magento/AsynchronousImportDataConverting/etc/di.xml
+++ b/app/code/Magento/AsynchronousImportDataConverting/etc/di.xml
@@ -17,12 +17,24 @@
     <type name="Magento\AsynchronousImportDataConverting\Model\ApplyConvertingRules">
         <arguments>
             <argument name="ruleApplyingStrategies" xsi:type="array">
-                <item name="uppercase_first_character" xsi:type="object">Magento\AsynchronousImportDataConverting\Model\RuleApplyingStrategy\UppercaseFirstCharacter\Proxy</item>
-                <item name="remove_field" xsi:type="object">Magento\AsynchronousImportDataConverting\Model\RuleApplyingStrategy\RemoveField\Proxy</item>
-                <item name="uppercase_string" xsi:type="object">Magento\AsynchronousImportDataConverting\Model\RuleApplyingStrategy\UppercaseString\Proxy</item>
-                <item name="string_replace" xsi:type="object">Magento\AsynchronousImportDataConverting\Model\RuleApplyingStrategy\StringReplace\Proxy</item>
-                <item name="yes_no_to_bool" xsi:type="object">Magento\AsynchronousImportDataConverting\Model\RuleApplyingStrategy\YesNoToBool\Proxy</item>
-                <item name="lowercase_string" xsi:type="object">Magento\AsynchronousImportDataConverting\Model\RuleApplyingStrategy\LowercaseString\Proxy</item>
+                <item name="uppercase_first_character" xsi:type="array">
+                    <item name="default" xsi:type="object">Magento\AsynchronousImportDataConverting\Model\RuleApplyingStrategy\UppercaseFirstCharacter\Proxy</item>
+                </item>
+                <item name="remove_field" xsi:type="array">
+                    <item name="default" xsi:type="object">Magento\AsynchronousImportDataConverting\Model\RuleApplyingStrategy\RemoveField\Proxy</item>
+                </item>
+                <item name="uppercase_string" xsi:type="array">
+                    <item name="default" xsi:type="object">Magento\AsynchronousImportDataConverting\Model\RuleApplyingStrategy\UppercaseString\Proxy</item>
+                </item>
+                <item name="string_replace" xsi:type="array">
+                    <item name="default" xsi:type="object">Magento\AsynchronousImportDataConverting\Model\RuleApplyingStrategy\StringReplace\Proxy</item>
+                </item>
+                <item name="yes_no_to_bool" xsi:type="array">
+                    <item name="default" xsi:type="object">Magento\AsynchronousImportDataConverting\Model\RuleApplyingStrategy\YesNoToBool\Proxy</item>
+                </item>
+                <item name="lowercase_string" xsi:type="array">
+                    <item name="default" xsi:type="object">Magento\AsynchronousImportDataConverting\Model\RuleApplyingStrategy\LowercaseString\Proxy</item>
+                </item>
             </argument>
         </arguments>
     </type>


### PR DESCRIPTION
I reworked list of conversion rules we have

### Description (*)
As we assume, that service can be installed as a Monolyth or as a Service, we need a way to create different conversion rules and differentiate between them.

So here how it will looks like:

```
<argument name="ruleApplyingStrategies" xsi:type="array">
                <item name="uppercase_first_character" xsi:type="array">
                    <item name="default" xsi:type="object">Magento\AsynchronousImportDataConverting\Model\RuleApplyingStrategy\UppercaseFirstCharacter\Proxy</item>
                    <item name="api" xsi:type="object">Magento\AsynchronousImportDataConverting\Model\RuleApplyingStrategy\UppercaseFirstCharacter\Proxy</item>
                </item>
</argument>
```

So developer or integrators could create new connection types and use those rules based on this connection types
